### PR TITLE
Bump dlist upper bound to 0.9

### DIFF
--- a/unordered-graphs.cabal
+++ b/unordered-graphs.cabal
@@ -27,7 +27,7 @@ library
   -- other-extensions:
   build-depends:       base >=4.8 && <4.9
                      , deepseq >= 1.4.0.0
-                     , dlist >= 0.5 && < 0.8
+                     , dlist >= 0.5 && < 0.9
                      , hashable
                      , unordered-containers == 0.2.*
   hs-source-dirs:      src


### PR DESCRIPTION
I just released [`dlist-0.8`](https://github.com/spl/dlist/releases/tag/v0.8). I didn't test this change to `unordered-graphs`, but I don't think it will be break anything.
